### PR TITLE
fix: require 5+ words for quiz and prevent cross-stage data merging

### DIFF
--- a/src/components/pages/FavoritesPage.tsx
+++ b/src/components/pages/FavoritesPage.tsx
@@ -88,7 +88,12 @@ export const FavoritesPage: React.FC<FavoritesPageProps> = ({ words, onStartQuiz
                 <>
                   <button
                     onClick={handleStartQuiz}
-                    className="px-6 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 font-medium transition duration-150 min-h-[44px]"
+                    disabled={favoriteWords.length < 5}
+                    className={`px-6 py-2 rounded-lg font-medium transition duration-150 min-h-[44px] ${
+                      favoriteWords.length < 5
+                        ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                        : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                    }`}
                   >
                     開始測驗
                   </button>
@@ -102,6 +107,13 @@ export const FavoritesPage: React.FC<FavoritesPageProps> = ({ words, onStartQuiz
               )}
             </div>
           </div>
+          {favoriteWords.length > 0 && favoriteWords.length < 5 && (
+            <div className="mt-4 p-4 rounded-lg bg-amber-50 border border-amber-200">
+              <p className="text-sm text-amber-800">
+                <span className="font-semibold">提醒：</span>建議累積至少 5 題再進行測驗，以確保測驗選項充足（目前 {favoriteWords.length} 題）
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Word cards */}


### PR DESCRIPTION
Addresses #6, #3

## Changes

### Issue #6: 重點訓練最少 5 題才能測驗
- ✅ 在 `FavoritesPage.tsx` 加入最少 5 題驗證
- ✅ 當重點訓練單字少於 5 題時，「開始測驗」按鈕會被禁用
- ✅ 顯示琥珀色提醒訊息：「建議累積至少 5 題再進行測驗，以確保測驗選項充足」
- ✅ 防止 ABCD 選項不足的問題

### Issue #3: 國中與高中資料互相獨立
- ✅ 修改 `useDataset.ts` 的合併邏輯
- ✅ 從單一 key (english_word) 改為複合 key (english_word + normalized_stage)
- ✅ 防止不同學程的單字合併成單一條目
- ✅ 範例：「please」的國中版和高中版現在會保持獨立
- ✅ 使用 `VersionService.normalizeStage()` 確保學程標準化

## Technical Details

### FavoritesPage Changes
```typescript
<button
  onClick={handleStartQuiz}
  disabled={favoriteWords.length < 5}
  className={favoriteWords.length < 5
    ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
    : 'bg-indigo-600 text-white hover:bg-indigo-700'
  }
>
  開始測驗
</button>

{favoriteWords.length > 0 && favoriteWords.length < 5 && (
  <div className="mt-4 p-4 rounded-lg bg-amber-50 border border-amber-200">
    <p className="text-sm text-amber-800">
      <span className="font-semibold">提醒：</span>建議累積至少 5 題再進行測驗
    </p>
  </div>
)}
```

### useDataset Changes
```typescript
// Before: const byWord = new Map(next.map(w => [w.english_word.toLowerCase(), w]));
// After: Composite key prevents cross-stage merging
const byWord = new Map(next.map(w => {
  const wordKey = String(w.english_word || '').toLowerCase();
  const stageKey = VersionService.normalizeStage(w.stage || '');
  return [\`\${wordKey}_\${stageKey}\`, w];
}));

// When looking up existing words
const wordKey = english.toLowerCase();
const incomingStageNormalized = VersionService.normalizeStage(incoming.stage || '');
const key = \`\${wordKey}_\${incomingStageNormalized}\`;
const existing = byWord.get(key);
```

## Testing Checklist
- ✅ `npm run build` 成功
- ✅ `npm run preview` 本地測試通過
- [ ] 案主測試：重點訓練少於 5 題時按鈕應該禁用
- [ ] 案主測試：「please」單字在國中/高中應該顯示各自獨立的資料

## Impact
- 防止測驗選項不足（Issue #6）
- 確保國中/高中資料不會混合（Issue #3）
- 改善使用者體驗和資料完整性

---

Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>