### PR TITLE
Fix: Book level auto-selection triggers lesson cascade

### DIFF
--- a/src/components/filters/TextbookFilters.tsx
+++ b/src/components/filters/TextbookFilters.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { TextbookIndexItem } from '../../types';
 import { useUserSettings } from '../../hooks/useUserSettings';
 import { VersionService } from '../../services/VersionService';
@@ -54,6 +54,13 @@ export const TextbookFilters: React.FC<TextbookFiltersProps> = ({
       )
     ).sort();
   }, [dataset.textbook_index, userSettings?.version, userSettings?.stage, filters.vol, availableVols]);
+
+  // Sync default vol selection when availableVols changes
+  useEffect(() => {
+    if (availableVols.length > 0 && !filters.vol && availableVols[0]) {
+      updateFilter('vol', availableVols[0]);
+    }
+  }, [availableVols, filters.vol, updateFilter]);
 
   // Show message if no data available
   if (availableVols.length === 0) {


### PR DESCRIPTION
Related to #25

## 🎯 Purpose
Fix issue where lesson list stays empty when identity is switched, even though book level (冊次) auto-selects to B1.

## 🔍 Root Cause Analysis (5 Whys)

1. **Why does lesson list stay empty?**
   → `availableLessons` doesn't recalculate when `filters.vol` changes programmatically

2. **Why doesn't it recalculate?**
   → The `useMemo` dependency works, but parent component doesn't call `updateFilter('vol', ...)`

3. **Why doesn't parent call updateFilter?**
   → Select element uses `value={filters.vol || availableVols[0]}` but doesn't trigger onChange for fallback

4. **Why doesn't fallback trigger onChange?**
   → React select elements only fire onChange on user interaction, not when value prop changes

5. **Root Cause**
   → No useEffect to sync default vol selection with parent state when `availableVols` changes

## ✅ Solution

Add `useEffect` that:
- Triggers when `availableVols` changes (after identity switch)
- Calls `updateFilter('vol', availableVols[0])` if `filters.vol` is undefined
- Ensures lesson list populates automatically without manual re-selection

## 🧪 Testing

- ✅ `npm run build` succeeds
- ✅ TypeScript type checking passes
- ✅ Single HTML output verified

## 📁 Files Changed

- `src/components/filters/TextbookFilters.tsx`: Added useEffect for default vol sync

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>