### PR TITLE
Fix: Prevent layout shift in lesson selection container

### DIFF
--- a/src/components/filters/TextbookFilters.tsx
+++ b/src/components/filters/TextbookFilters.tsx
@@ -136,21 +136,27 @@ export const TextbookFilters: React.FC<TextbookFiltersProps> = ({
             </button>
           </div>
         </div>
-        <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 p-3 border border-gray-300 rounded-lg max-h-40 overflow-y-auto">
-          {availableLessons.filter((l): l is string => l !== undefined).map(lesson => (
-            <label
-              key={lesson}
-              className="flex items-center space-x-2 cursor-pointer hover:bg-gray-50 p-1 rounded"
-            >
-              <input
-                type="checkbox"
-                checked={selectedLessons.includes(lesson)}
-                onChange={() => handleLessonToggle(lesson)}
-                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-              />
-              <span className="text-sm">{lesson}</span>
-            </label>
-          ))}
+        <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 p-3 border border-gray-300 rounded-lg max-h-40 overflow-y-auto min-h-[120px]">
+          {availableLessons.length === 0 ? (
+            <div className="col-span-3 sm:col-span-4 flex items-center justify-center text-gray-400 text-sm min-h-[96px]">
+              {filters.vol ? '載入中...' : '請選擇冊次'}
+            </div>
+          ) : (
+            availableLessons.filter((l): l is string => l !== undefined).map(lesson => (
+              <label
+                key={lesson}
+                className="flex items-center space-x-2 cursor-pointer hover:bg-gray-50 p-1 rounded"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedLessons.includes(lesson)}
+                  onChange={() => handleLessonToggle(lesson)}
+                  className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="text-sm">{lesson}</span>
+              </label>
+            ))
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Related to #26

## 🎯 Purpose
Fix layout shift (佈局跳動) caused by inconsistent container height when lesson list is empty vs loaded.

## 🔍 Root Cause Analysis (5 Whys)

1. **Why does height change?**
   → Container has no min-height, height is determined by content only

2. **Why is that a problem?**
   → Content below gets pushed down when lessons load, creating jarring layout shift

3. **Why does content load after render?**
   → Lessons depend on vol (冊次) selection, which may not be set initially

4. **Why doesn't it show loading state?**
   → No placeholder text or loading indicator when lessons array is empty

5. **Root Cause**
   → Container lacks fixed/minimum height and empty state UI guidance

## ✅ Solution

### 1. Consistent Height
- Add `min-h-[120px]` to lesson container
- Prevents content below from shifting when lessons populate

### 2. Empty State UI
When `availableLessons.length === 0`, show contextual message:
- **"載入中..."** - when `filters.vol` is selected (data loading)
- **"請選擇冊次"** - when no vol selected yet (user guidance)

### 3. Visual Improvements
- Center-aligned empty state text
- Gray color (`text-gray-400`) for non-intrusive appearance
- Maintains consistent padding and border

## 🧪 Testing

- ✅ `npm run build` succeeds
- ✅ TypeScript type checking passes
- ✅ Single HTML output verified (5.47 MB)

## 📁 Files Changed

- `src/components/filters/TextbookFilters.tsx`: 
  - Added min-height constraint
  - Implemented empty state conditional rendering
  - Enhanced UX with contextual messages

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>