### PR TITLE
Fix: Correct terminology from '程度分級' to '主題探索'

### DIFF
--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -16,7 +16,7 @@ import { ThemeFilters } from '../filters/ThemeFilters';
 const TABS = {
   textbook: '課本進度',
   exam: '大考衝刺',
-  theme: '程度分級'
+  theme: '主題探索'
 };
 
 interface HomePageProps {
@@ -108,7 +108,7 @@ export const HomePage: React.FC<HomePageProps> = ({ words, userSettings }) => {
       {/* Welcome Section */}
       <div className="text-gray-600 mb-6 leading-relaxed space-y-1">
         <p className="text-lg font-medium text-gray-500">歡迎來到 WordGym 單字健身坊！</p>
-        <p className="text-base text-gray-500">請從課本進度、大考衝刺或程度分級，選擇想要學習的內容！</p>
+        <p className="text-base text-gray-500">請從課本進度、大考衝刺或主題探索，選擇想要學習的內容！</p>
       </div>
 
       {/* Tab Navigation - Updated styling to match original */}
@@ -201,7 +201,7 @@ export const HomePage: React.FC<HomePageProps> = ({ words, userSettings }) => {
             <h2 className="text-xl font-semibold">
               {currentTab === 'textbook' && '課本進度'}
               {currentTab === 'exam' && '大考衝刺（歷屆試題）'}
-              {currentTab === 'theme' && '程度分級（Level 分類）'}
+              {currentTab === 'theme' && '主題探索（Level 分類）'}
             </h2>
             <p className="text-sm text-gray-500">
               符合條件的單字：{filteredWords.length} 筆


### PR DESCRIPTION
Related to #24

## 🎯 Purpose
Fix incorrect terminology in UI text - replace "程度分級" (Level Classification) with "主題探索" (Theme Exploration).

## 🔍 Root Cause Analysis (5 Whys)

1. **Why is the text wrong?**
   → Hardcoded string "程度分級" in source code

2. **Why was it hardcoded incorrectly?**
   → Copy-paste error or outdated terminology during development

3. **Why wasn't it caught earlier?**
   → No systematic UI text review process

4. **Why does it matter?**
   → Incorrect terminology confuses users about feature purpose and functionality

5. **Root Cause**
   → Incorrect terminology hardcoded in multiple UI locations (tabs, welcome message, heading)

## ✅ Solution

Replaced all 3 instances of "程度分級" with "主題探索":

### 1. TABS Constant (Line 19)
```typescript
// Before
theme: '程度分級'

// After
theme: '主題探索'
```

### 2. Welcome Message (Line 111)
```typescript
// Before
請從課本進度、大考衝刺或程度分級，選擇想要學習的內容！

// After
請從課本進度、大考衝刺或主題探索，選擇想要學習的內容！
```

### 3. Results Section Heading (Line 204)
```typescript
// Before
{currentTab === 'theme' && '程度分級（Level 分類）'}

// After
{currentTab === 'theme' && '主題探索（Level 分類）'}
```

### Verification
- ✅ Grep search confirms no remaining instances of "程度分級"
- ✅ All UI text now uses correct terminology

## 🧪 Testing

- ✅ `npm run build` succeeds
- ✅ TypeScript type checking passes
- ✅ Single HTML output verified (5.47 MB)

## 📁 Files Changed

- `src/components/pages/HomePage.tsx`: Updated 3 instances of terminology

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>