### PR TITLE
Fix: Enforce strict stage filtering to separate 國中 and 高中 data

### DIFF
--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -10,6 +10,7 @@ import type {
   Filters,
   POSType
 } from '../types';
+import { VersionService } from '../services/VersionService';
 
 /**
  * Core filtering logic for vocabulary words
@@ -42,10 +43,14 @@ export function getFilteredWords(
     // Removed logging;
     // Removed logging;
 
+    // STRICT stage filtering - normalize both sides for comparison
+    // Fix for Issue #31: 國高中資料必須互相獨立
+    const normalizedUserStage = VersionService.normalizeStage(userSettings.stage);
+
     filtered = filtered.filter(word => {
-      const hasMatchingStage = word.stage === userSettings.stage;
-      const hasNoStage = !word.stage;
-      return hasMatchingStage || hasNoStage;
+      if (!word.stage) return false; // Exclude words with no stage
+      const normalizedWordStage = VersionService.normalizeStage(word.stage);
+      return normalizedWordStage === normalizedUserStage;
     });
 
     // Removed logging: ${filtered.length} words remaining`);


### PR DESCRIPTION
Related to #31

## 🎯 Purpose
Enforce strict separation between 國中 and 高中 vocabulary data to prevent cross-stage contamination.

## 🔍 Root Cause Analysis (5 Whys)
**Problem**: Words showing both 國中 and 高中 tags mixed

1. Why? → filterUtils.ts allows words with no stage to pass through
2. Why? → Line 48 has `|| hasNoStage` condition
3. Why? → Permissive filtering logic assumed missing stage = valid
4. Why? → No stage normalization for comparison
5. Why? → Missing VersionService integration

**Root Cause**: filterUtils.ts used permissive logic (hasMatchingStage || hasNoStage) instead of strict matching

## ✅ Solution
**File Modified**: `src/utils/filterUtils.ts` (lines 46-54)

### Changes:
1. Import VersionService for stage normalization
2. Use `VersionService.normalizeStage()` to normalize both:
   - User's selected stage (國中/高中 → junior/high)
   - Word's stage field
3. Remove permissive `|| hasNoStage` condition
4. Explicitly exclude words without stage (`if (!word.stage) return false`)

### Before (Permissive):
```typescript
filtered = filtered.filter(word => {
  const hasMatchingStage = word.stage === userSettings.stage;
  const hasNoStage = !word.stage;
  return hasMatchingStage || hasNoStage;  // Allows no-stage words through
});
```

### After (Strict):
```typescript
const normalizedUserStage = VersionService.normalizeStage(userSettings.stage);

filtered = filtered.filter(word => {
  if (!word.stage) return false; // Exclude words with no stage
  const normalizedWordStage = VersionService.normalizeStage(word.stage);
  return normalizedWordStage === normalizedUserStage;
});
```

## 🧪 Testing
- ✅ TypeScript compilation passed
- ✅ Build succeeded (5,468.96 kB)
- ⏳ Awaiting Chrome verification in production

## 📊 Expected Impact
- When stage="高中", ONLY show words with stage="高中" or "high"
- When stage="國中", ONLY show words with stage="國中" or "junior"
- Words with missing stage field will be excluded from both
- Prevents cross-stage data leakage

## 🔗 Related Files
- `src/utils/filterUtils.ts` - Core filtering logic
- `src/services/VersionService.ts` - Stage normalization

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>