### PR TITLE
Fix: Merge instruction cards in 重點訓練 default screen

### DIFF
--- a/src/components/pages/FavoritesPage.tsx
+++ b/src/components/pages/FavoritesPage.tsx
@@ -119,9 +119,16 @@ export const FavoritesPage: React.FC<FavoritesPageProps> = ({ words, onStartQuiz
         {/* Word cards */}
         {favoriteWords.length === 0 ? (
           <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
-            <p className="text-gray-500">尚未加入任何重點訓練單字</p>
-            <p className="text-sm text-gray-400 mt-2">
-              在單字學習區，如果有不熟的單字，可以加入重點訓練
+            <div className="mb-4">
+              <img
+                src="https://github.com/user-attachments/assets/346a31c6-d570-4eab-9156-b4715c4eb14f"
+                alt="重點訓練提示"
+                className="mx-auto max-w-sm w-full"
+              />
+            </div>
+            <h3 className="text-xl font-semibold text-gray-700 mb-2">重點訓練（0）</h3>
+            <p className="text-gray-500">
+              請同學把不熟悉的單字儲存至重點訓練，加強複習或是進行測驗！
             </p>
           </div>
         ) : (


### PR DESCRIPTION
Related to #29

## 🎯 Purpose
Merge 2 separate instruction cards into 1 unified card with illustration in the 重點訓練 (Favorites) empty state screen.

## 📝 Changes
**File Modified**: `src/components/pages/FavoritesPage.tsx` (lines 120-133)

### Before:
```tsx
<div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
  <p className="text-gray-500">尚未加入任何重點訓練單字</p>
  <p className="text-sm text-gray-400 mt-2">
    在單字學習區，如果有不熟的單字，可以加入重點訓練
  </p>
</div>
```

### After:
```tsx
<div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
  <div className="mb-4">
    <img
      src="https://github.com/user-attachments/assets/346a31c6-d570-4eab-9156-b4715c4eb14f"
      alt="重點訓練提示"
      className="mx-auto max-w-sm w-full"
    />
  </div>
  <h3 className="text-xl font-semibold text-gray-700 mb-2">重點訓練（0）</h3>
  <p className="text-gray-500">
    請同學把不熟悉的單字儲存至重點訓練，加強複習或是進行測驗！
  </p>
</div>
```

## ✅ Implementation Details
1. **Added illustration image** from issue spec (GitHub-hosted)
2. **Merged text** into single unified message
3. **Updated heading** to show "重點訓練（0）"
4. **Improved visual hierarchy** with h3 + p structure

## 🧪 Testing
- ✅ TypeScript compilation passed
- ✅ Build succeeded (5,469.17 kB)
- ⏳ Awaiting Chrome verification in production

## 📊 Expected Outcome
- Empty state shows single instruction card with image
- Clear guidance for students on how to use 重點訓練
- Better visual consistency with Issue #30 (Quiz default screen)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>