### PR TITLE
Fix: Replace empty state image in 實力驗收 default screen

### DIFF
--- a/src/components/pages/QuizPage.tsx
+++ b/src/components/pages/QuizPage.tsx
@@ -89,22 +89,16 @@ export const QuizPage: React.FC<QuizPageProps> = ({ words, userSettings }) => {
   if (quizWords.length === 0) {
     return (
       <div className="container mx-auto p-6 max-w-2xl">
-        <div className="text-center py-12 bg-gradient-to-br from-orange-50 to-yellow-50 rounded-2xl border-2 border-orange-200">
-          <svg
-            className="mx-auto h-16 w-16 text-orange-400 mb-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+        <div className="text-center py-12 bg-white rounded-2xl shadow-sm border border-gray-100">
+          <div className="mb-4">
+            <img
+              src="https://github.com/user-attachments/assets/5f5790d7-c550-47b5-b9d0-eca7e71503f3"
+              alt="實力驗收提示"
+              className="mx-auto max-w-sm w-full"
             />
-          </svg>
-          <p className="text-gray-800 text-lg font-semibold mb-2">請先選擇題目範圍</p>
-          <p className="text-gray-600 mb-6">請先到「單字卡」選擇題目範圍</p>
+          </div>
+          <h3 className="text-xl font-semibold text-gray-700 mb-2">實力驗收（0）</h3>
+          <p className="text-gray-500 mb-6">請同學到單字卡區選擇測驗範圍</p>
           <button
             onClick={() => window.location.hash = '#/'}
             className="px-6 py-3 bg-indigo-600 text-white rounded-xl hover:bg-indigo-700 font-medium transition shadow-md hover:shadow-lg"


### PR DESCRIPTION
Related to #30

## 🎯 Purpose
Replace empty state SVG warning icon with illustration image in 實力驗收 (Quiz) default screen to improve visual consistency with Issue #29.

## 📝 Changes
**File Modified**: `src/components/pages/QuizPage.tsx` (lines 89-111)

### Before:
```tsx
<div className="text-center py-12 bg-gradient-to-br from-orange-50 to-yellow-50 rounded-2xl border-2 border-orange-200">
  <svg className="mx-auto h-16 w-16 text-orange-400 mb-4" ...>
    <path ... />
  </svg>
  <p className="text-gray-800 text-lg font-semibold mb-2">請先選擇題目範圍</p>
  <p className="text-gray-600 mb-6">請先到「單字卡」選擇題目範圍</p>
  ...
</div>
```

### After:
```tsx
<div className="text-center py-12 bg-white rounded-2xl shadow-sm border border-gray-100">
  <div className="mb-4">
    <img
      src="https://github.com/user-attachments/assets/5f5790d7-c550-47b5-b9d0-eca7e71503f3"
      alt="實力驗收提示"
      className="mx-auto max-w-sm w-full"
    />
  </div>
  <h3 className="text-xl font-semibold text-gray-700 mb-2">實力驗收（0）</h3>
  <p className="text-gray-500 mb-6">請同學到單字卡區選擇測驗範圍</p>
  ...
</div>
```

## ✅ Implementation Details
1. **Replaced SVG warning icon** with GitHub-hosted illustration
2. **Updated heading** to "實力驗收（0）"
3. **Simplified instruction** to match product spec
4. **Improved visual consistency** with Issue #29 (clean white card style)
5. **Removed gradient background** for simpler design

## 🧪 Testing
- ✅ TypeScript compilation passed
- ✅ Build succeeded (5,468.39 kB)
- ⏳ Awaiting Chrome verification in production

## 📊 Expected Outcome
- Empty state shows illustration with clear heading
- Visual consistency with 重點訓練 empty state (Issue #29)
- Better user guidance for quiz range selection

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>