### PR TITLE
fix: update Favorites default screen UI and add navigation button (Related to #29)

### DIFF
--- a/src/components/pages/FavoritesPage.tsx
+++ b/src/components/pages/FavoritesPage.tsx
@@ -119,17 +119,24 @@ export const FavoritesPage: React.FC<FavoritesPageProps> = ({ words, onStartQuiz
         {/* Word cards */}
         {favoriteWords.length === 0 ? (
           <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
-            <div className="mb-4">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-2">重點訓練（0）</h2>
+            <p className="text-gray-600 mb-6">
+              目前沒有加入重點訓練的單字喔！<br />
+              請在「單字卡區」收藏不熟的單字，我們就會為你自動匯入，幫助你精準複習！
+            </p>
+            <button
+              onClick={() => window.location.hash = '#/'}
+              className="mb-6 px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 font-medium transition duration-150"
+            >
+              立即前往單字卡
+            </button>
+            <div>
               <img
-                src="https://github.com/user-attachments/assets/346a31c6-d570-4eab-9156-b4715c4eb14f"
-                alt="重點訓練提示"
-                className="mx-auto max-w-sm w-full"
+                src="https://github.com/user-attachments/assets/22a99160-2944-4600-b8c5-a1152624fb5c"
+                alt="背單字女孩插圖"
+                className="mx-auto max-w-md w-full"
               />
             </div>
-            <h3 className="text-xl font-semibold text-gray-700 mb-2">重點訓練（0）</h3>
-            <p className="text-gray-500">
-              請同學把不熟悉的單字儲存至重點訓練，加強複習或是進行測驗！
-            </p>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## 問題描述

重點訓練預設畫面需要更新：
1. 文字內容
2. 圖片
3. 新增導航按鈕「立即前往單字卡」

## 🧪 新系統測試：feedback-parser Analysis

### Step 1-2: 提取關鍵詞
- 動詞: 改文字, 置換圖片, 加上按鈕, 連結至
- 名詞: 文字, 圖片, 按鈕, 單字卡區

### Step 3: 組合分析
- **需求類型**: UI問題 + 功能問題
- **所有需求都很明確** ✅
- **不需要詢問案主** ✅

### Step 4: 需求確認清單
1. ✅ 更新文字內容（逐字稿已提供）
2. ✅ 替換圖片 URL（已提供）
3. ✅ 新增按鈕「立即前往單字卡」（位置、文字已明確）
4. ✅ 按鈕導航至單字卡區（功能已說明）

### Step 5: 決策
→ 需求 100% 明確，直接實施 ✅

## 解決方案

更新 FavoritesPage.tsx 空狀態顯示 (lines 121-140)：

**新內容**：
```tsx
<h2>重點訓練（0）</h2>
<p>
  目前沒有加入重點訓練的單字喔！<br />
  請在「單字卡區」收藏不熟的單字，我們就會為你自動匯入，幫助你精準複習！
</p>
<button onClick={() => window.location.hash = '#/'}>
  立即前往單字卡
</button>
<img src="https://github.com/user-attachments/assets/22a99160-2944-4600-b8c5-a1152624fb5c" 
     alt="背單字女孩插圖" />
```

## 修改內容

**src/components/pages/FavoritesPage.tsx**:
- 更新標題文字
- 更新說明文字（2行）
- 新增導航按鈕（indigo 主題色，hover 效果）
- 更新圖片 URL 和 alt 文字

## ⚠️ 待辦：Chrome 驗證（新流程要求）

根據新的強制 Chrome 驗證流程，需要：

### Chrome 驗證報告模板

\`\`\`markdown
## Chrome 生產環境驗證報告

**修復內容**: 重點訓練預設畫面更新
**驗證時間**: [待填寫]
**生產 URL**: https://youngger9765.github.io/WordGym-students-merge/

### 修復前 (BEFORE)
[需要截圖：舊的預設畫面]
- 舊文字："請同學把不熟悉的單字儲存至重點訓練，加強複習或是進行測驗！"
- 舊圖片：健身男孩插圖
- 無導航按鈕

### 修復後 (AFTER)  
[需要截圖：新的預設畫面]
- ✅ 新文字："目前沒有加入重點訓練的單字喔！請在「單字卡區」收藏不熟的單字..."
- ✅ 新圖片：背單字女孩插圖
- ✅ 新按鈕：「立即前往單字卡」（點擊導航至首頁）

### 驗證結果
- [ ] 文字內容正確
- [ ] 圖片顯示正確
- [ ] 按鈕存在且樣式正確
- [ ] 點擊按鈕正確導航至 /#/
- [ ] Console 無錯誤
- [ ] 其他功能未受影響

### 測試環境
- Browser: Chrome [版本]
- Device: [設備]
- Screen Size: [尺寸]

### 結論
✅ **驗證通過** / ❌ **驗證失敗**

理由: [待測試]
\`\`\`

**⚠️ 按照新流程，此驗證報告必須完成並貼到 Issue #29 才能標記為 ready-for-testing**

## 相關 Issue

Related to #29

## 檢查清單

- [x] 程式碼已通過 TypeScript 編譯
- [x] Build 成功（dist/index.html: 5,468.94 kB）
- [x] 使用新 feedback-parser 系統分析需求
- [x] 需求 100% 明確，無需詢問案主
- [ ] **Chrome 驗證報告**（待完成） ⭐ NEW
- [ ] BEFORE/AFTER 截圖（待完成） ⭐ NEW

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)