### PR TITLE
fix: update Quiz default screen UI and add navigation button (Related to #30)

### DIFF
--- a/src/components/pages/QuizPage.tsx
+++ b/src/components/pages/QuizPage.tsx
@@ -90,21 +90,24 @@ export const QuizPage: React.FC<QuizPageProps> = ({ words, userSettings }) => {
     return (
       <div className="container mx-auto p-6 max-w-2xl">
         <div className="text-center py-12 bg-white rounded-2xl shadow-sm border border-gray-100">
-          <div className="mb-4">
-            <img
-              src="https://github.com/user-attachments/assets/5f5790d7-c550-47b5-b9d0-eca7e71503f3"
-              alt="實力驗收提示"
-              className="mx-auto max-w-sm w-full"
-            />
-          </div>
-          <h3 className="text-xl font-semibold text-gray-700 mb-2">實力驗收（0）</h3>
-          <p className="text-gray-500 mb-6">請同學到單字卡區選擇測驗範圍</p>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-2">實力驗收（0）</h2>
+          <p className="text-gray-600 mb-6">
+            你還沒有選擇挑戰範圍喔！<br />
+            請先在「單字卡」熟悉內容，累積足夠實力後再來這裡進行挑戰！
+          </p>
           <button
             onClick={() => window.location.hash = '#/'}
-            className="px-6 py-3 bg-indigo-600 text-white rounded-xl hover:bg-indigo-700 font-medium transition shadow-md hover:shadow-lg"
+            className="mb-6 px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 font-medium transition duration-150"
           >
-            前往單字卡
+            立即前往單字卡
           </button>
+          <div>
+            <img
+              src="https://github.com/user-attachments/assets/e05d58f4-64fb-4fa7-89ea-65aaabdcc804"
+              alt="健身男孩插圖"
+              className="mx-auto max-w-md w-full"
+            />
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## 問題描述

實力驗收預設畫面需要優化：
1. 更新文案
2. 更新圖檔
3. 新增導航按鈕「立即前往單字卡」

## 🧪 新系統測試：feedback-parser Analysis  

### Step 1-2: 提取關鍵詞
- 動詞: 更新文案, 更新圖檔, 加上按鈕, 連結到
- 名詞: 文案, 圖檔, 按鈕, 單字卡區

### Step 3: 組合分析
- **需求類型**: UI問題 + 功能問題
- **所有需求都很明確** ✅
- **不需要詢問案主** ✅

### Step 4: 需求確認清單
1. ✅ 更新文案（逐字稿已提供）
2. ✅ 更新圖檔 URL（已提供 - 健身男孩）
3. ✅ 新增按鈕「立即前往單字卡」（位置、文字已明確）
4. ✅ 按鈕在圖檔上方
5. ✅ 完成示意圖已提供

### Step 5: 決策
→ 需求 100% 明確，直接實施 ✅

## 解決方案

更新 QuizPage.tsx 空狀態顯示 (lines 89-114)：

**新內容**：
```tsx
<h2>實力驗收（0）</h2>
<p>
  你還沒有選擇挑戰範圍喔！<br />
  請先在「單字卡」熟悉內容，累積足夠實力後再來這裡進行挑戰！
</p>
<button onClick={() => window.location.hash = '#/'}>
  立即前往單字卡
</button>
<img src="https://github.com/user-attachments/assets/e05d58f4-64fb-4fa7-89ea-65aaabdcc804" 
     alt="健身男孩插圖" />
```

**元素順序**（重要）：
1. 標題
2. 文案
3. **按鈕**（在圖片上方）
4. 圖片

## 修改內容

**src/components/pages/QuizPage.tsx**:
- 更新標題文字
- 更新說明文案（2行）
- 新增導航按鈕（indigo 主題色）
- 按鈕位置：圖檔上方 ✅
- 更新圖檔 URL（健身男孩）

## ⚠️ 待辦：Chrome 驗證（新流程要求）

根據新的強制 Chrome 驗證流程，需要：

### Chrome 驗證報告模板

\`\`\`markdown
## Chrome 生產環境驗證報告

**修復內容**: 實力驗收預設畫面更新
**驗證時間**: [待填寫]
**生產 URL**: https://youngger9765.github.io/WordGym-students-merge/#/quiz

### 修復前 (BEFORE)
[需要截圖：舊的預設畫面]
- 舊文案："請同學到單字卡區選擇測驗範圍"
- 舊圖片：其他插圖
- 按鈕文字："前往單字卡"

### 修復後 (AFTER)  
[需要截圖：新的預設畫面]
- ✅ 新文案："你還沒有選擇挑戰範圍喔！請先在「單字卡」熟悉內容..."
- ✅ 新圖片：健身男孩插圖
- ✅ 新按鈕：「立即前往單字卡」
- ✅ 按鈕在圖片上方 ✅

### 驗證結果
- [ ] 文案內容正確
- [ ] 圖片顯示正確（健身男孩）
- [ ] 按鈕位置正確（圖片上方）
- [ ] 按鈕文字正確（「立即前往單字卡」）
- [ ] 點擊按鈕正確導航至 /#/
- [ ] Console 無錯誤

### 測試環境
- Browser: Chrome [版本]
- Device: [設備]

### 結論
✅ **驗證通過** / ❌ **驗證失敗**

理由: [待測試]
\`\`\`

**⚠️ 此驗證報告必須完成並貼到 Issue #30 才能標記為 ready-for-testing**

## 相關 Issue

Related to #30

## 檢查清單

- [x] 程式碼已通過 TypeScript 編譯
- [x] Build 成功（dist/index.html: 5,468.41 kB）
- [x] 使用新 feedback-parser 系統分析需求
- [x] 需求 100% 明確，無需詢問案主
- [ ] **Chrome 驗證報告**（待完成） ⭐ NEW
- [ ] BEFORE/AFTER 截圖（待完成） ⭐ NEW

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)