### PR TITLE
fix(quiz): implement responsive flashcard width with 1200px max-width (#19)

### DIFF
--- a/src/components/quiz/FlashcardQuiz.tsx
+++ b/src/components/quiz/FlashcardQuiz.tsx
@@ -374,7 +374,8 @@ const FlashcardQuiz: React.FC<FlashcardQuizProps> = ({ words, onRestart }) => {
           perspective: 1000px;
           margin-bottom: 100px;
           width: 100%;
-          max-width: 900px;
+          max-width: 1200px;
+          min-width: 280px;
           margin-left: auto;
           margin-right: auto;
         }


### PR DESCRIPTION
## 問題描述

閃卡正反面寬度不一致，經過 2 次失敗嘗試後，案主明確選擇「方案 A：響應式 + 合理上限 1200px」。

## 修復內容

### 技術實現
**檔案**: `src/components/quiz/FlashcardQuiz.tsx:373-381`

```css
.flashcard {
  perspective: 1000px;
  margin-bottom: 100px;
  width: 100%;           /* 保持響應式 */
  max-width: 1200px;     /* 從 900px 改為 1200px */
  min-width: 280px;      /* 新增：避免極窄屏幕斷行 */
  margin-left: auto;
  margin-right: auto;
}
```

### 變更說明
- ✅ `max-width: 900px` → `1200px` (避免極寬屏幕可讀性問題)
- ✅ 新增 `min-width: 280px` (避免極窄屏幕斷行問題)
- ✅ 保持 `width: 100%` 響應式設計

### 預期效果
1. **響應式優勢**：小於 1200px 屏幕自動調整，充分利用空間
2. **大屏保護**：1920px+ 顯示器固定 1200px，避免過長影響可讀性
3. **小屏保護**：280px+ 防止極窄屏幕斷行
4. **寬度一致**：正反面使用相同容器，max-width 對兩者一視同仁

### 方案選擇歷程
- ❌ 第 1 次嘗試 (713a353): max-width: 600px → 案主反饋「太窄」
- ❌ 第 2 次嘗試 (f0340e7): max-width: 900px → 案主反饋「句子斷行，破壞設計」
- ✅ 遵循 failed-fix-principle，停止猜測，詢問案主需求
- ✅ 案主明確選擇「方案 A：響應式 + 合理上限 1200px」

## 驗證方式

### 瀏覽器測試（必須）
**Production URL**: https://youngger9765.github.io/WordGym-students-merge/

**測試步驟**:
1. 進入閃卡測驗（任意課本進度 → 閃卡）
2. 測試短單字（如 "go", "put"）
3. 測試長片語（如 "around the corner"）
4. 驗證正反面翻轉時寬度保持一致
5. 調整瀏覽器視窗大小，驗證響應式行為：
   - 小屏（<1200px）：卡片寬度 = 視窗寬度
   - 大屏（>1200px）：卡片寬度 = 1200px（固定）

### Chrome 驗證報告模板

```markdown
## Chrome Production Environment Verification Report

**修復內容**: 閃卡響應式寬度（方案 A）
**驗證時間**: [填寫時間]
**Production URL**: https://youngger9765.github.io/WordGym-students-merge/

### Before Fix (BEFORE)
- max-width: 900px
- 句子斷行，破壞原設計

### After Fix (AFTER)  
- max-width: 1200px
- 響應式 + 合理上限
- 正反面寬度一致

### 驗證結果
- [ ] 短單字卡片寬度正常
- [ ] 長片語卡片寬度正常
- [ ] 正反面翻轉時寬度一致
- [ ] 小屏響應式正常（<1200px）
- [ ] 大屏固定寬度正常（>1200px）
- [ ] Console 無錯誤

### Test Environment
- Browser: Chrome [version]
- Device: [device info]
- Screen Sizes Tested: [e.g., 375px, 768px, 1024px, 1920px]

### Conclusion
✅ **Verification Passed** / ❌ **Verification Failed**

Reason: [explanation]
```

## 相關 Issue

Closes #19

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)